### PR TITLE
Updated command examples.

### DIFF
--- a/Command/ViewContentCommand.php
+++ b/Command/ViewContentCommand.php
@@ -34,6 +34,7 @@ class ViewContentCommand extends ContainerAwareCommand
         /** @var $repository \eZ\Publish\API\Repository\Repository */
         $repository = $this->getContainer()->get( 'ezpublish.api.repository' );
         $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
         $fieldTypeService = $repository->getFieldTypeService();
 
         $contentId = $input->getArgument( 'contentId' );
@@ -41,9 +42,10 @@ class ViewContentCommand extends ContainerAwareCommand
         try
         {
             $content = $contentService->loadContent( $contentId );
+            $contentType = $contentTypeService->loadContentType( $content->contentInfo->contentTypeId );
 
             // Iterate over the field definitions of the content type, and print identifier: value
-            foreach ( $content->contentType->fieldDefinitions as $fieldDefinition )
+            foreach ( $contentType->fieldDefinitions as $fieldDefinition )
             {
                 $output->writeln( "<info>" . $fieldDefinition->identifier . "</info>" );
                 $fieldType = $fieldTypeService->getFieldType( $fieldDefinition->fieldTypeIdentifier );

--- a/Command/ViewContentMetaDataCommand.php
+++ b/Command/ViewContentMetaDataCommand.php
@@ -31,6 +31,7 @@ class ViewContentMetaDataCommand extends ContainerAwareCommand
         /** @var $repository \eZ\Publish\API\Repository\Repository */
         $repository = $this->getContainer()->get( 'ezpublish.api.repository' );
         $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
         $locationService = $repository->getLocationService();
         $urlAliasService = $repository->getURLAliasService();
         $sectionService = $repository->getSectionService();
@@ -43,6 +44,7 @@ class ViewContentMetaDataCommand extends ContainerAwareCommand
         try
         {
             $contentInfo = $contentService->loadContentInfo( $contentId );
+            $contentType = $contentTypeService->loadContentType( $contentInfo->contentTypeId );
 
             // show all locations of the content
             $locations = $locationService->loadLocations( $contentInfo );
@@ -69,7 +71,7 @@ class ViewContentMetaDataCommand extends ContainerAwareCommand
             // show meta data
             $output->writeln( "\n<info>METADATA</info>" );
             $output->writeln( "  <info>Name:</info> $contentInfo->name" );
-            $output->writeln( "  <info>Type:</info> " .$contentInfo->contentType->identifier );
+            $output->writeln( "  <info>Type:</info> " . $contentType->identifier );
             $output->writeln( "  <info>Last modified:</info> " . $contentInfo->modificationDate->format( 'Y-m-d' ) );
             $output->writeln( "  <info>Published:</info> ". $contentInfo->publishedDate->format( 'Y-m-d' ) );
             $output->writeln( "  <info>RemoteId:</info> $contentInfo->remoteId" );


### PR DESCRIPTION
Reading through the cook book examples today I noticed that contentType property are not available in content or contentInfo, causing ViewContentCommand and ViewContentMetaDataCommand to fail when run.
