### PR TITLE
Update deletesubtree.php

### DIFF
--- a/Command/DeleteSubtree.php
+++ b/Command/DeleteSubtree.php
@@ -38,8 +38,8 @@ class DeleteSubtree extends ContainerAwareCommand
         try
         {
             // We first try to load the location so that a NotFoundException is thrown if the Location doesn't exist
-            $locationService->loadLocation( $locationId );
-            $locationService->deleteLocation( $locationId );
+            $location = $locationService->loadLocation( $locationId );
+            $locationService->deleteLocation( $location );
         }
         catch ( \eZ\Publish\API\Repository\Exceptions\NotFoundException $e )
         {


### PR DESCRIPTION
eZ\Publish\Core\SignalSlot\LocationService::deleteLocation() must be an instance of eZ\Publish\API\Repository\Values\Content\Location, integer given. 
Changed to pass the $location to the deleteLocation() function.