### PR TITLE
Make CookbookBundle work with eZ Platform

### DIFF
--- a/Command/CreateXmlContentCommand.php
+++ b/Command/CreateXmlContentCommand.php
@@ -1,10 +1,9 @@
 <?php
 /**
- * File containing the CreateXMLContentCommand class.
+ * File containing the CreateXmlContentCommand class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\CookbookBundle\Command;
 

--- a/Command/FindContentCommand.php
+++ b/Command/FindContentCommand.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
  * File containing the FindContentCommand class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- * @version //autogentag//
  */
 namespace EzSystems\CookbookBundle\Command;
 
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use eZ\Publish\API\Repository\Values\Content\Query;
 
 /**
  * This command performs a simple full text search
@@ -38,7 +38,7 @@ class FindContentCommand extends ContainerAwareCommand
 
         $text = $input->getArgument( 'text' );
 
-        $query = new \eZ\Publish\API\Repository\Values\Content\Query();
+        $query = new Query();
         // Use 'query' over 'filter' to get hit score (relevancy) and default sorting by it with Solr/Elastic
         $query->query = new Query\Criterion\FullText( $text );
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EzSystems\CookBookBundle\DependencyInjection;
+namespace EzSystems\CookbookBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/DependencyInjection/EzSystemsCookbookExtension.php
+++ b/DependencyInjection/EzSystemsCookbookExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class eZCookBookExtension extends Extension
+class EzSystemsCookbookExtension extends Extension
 {
     /**
      * {@inheritDoc}

--- a/EzSystemsCookbookBundle.php
+++ b/EzSystemsCookbookBundle.php
@@ -6,5 +6,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsCookbookBundle extends Bundle
 {
-    protected $name = 'EzSystemsCookbookBundle';
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,62 @@
 CookbookBundle
 ==============
 
-This reposiotry contains a eZ Publish 5.x Cookbook Bundle, full of working examples for using eZ Publish 5.x Public API.
+This repository contains a eZ Publish 5.x and eZ Platform Cookbook Bundle, full of working examples for using eZ Publish 5.x and eZ Platform Public API.
+
+# Getting started
+
+Required tools:
+
+- PHP (`7.0+` is recommended)
+- Composer
+- Git
+
+1. Create and install eZ Platform using composer:
+
+    ```bash
+    composer create-project ezsystems/ezplatform
+    ```
+
+    Follow the instructions that show up on the screen to have fully working clean install of eZ Platform.
+
+2. Clone (using git) `CookbookBundle` into your eZ Platform project:
+
+    ```bash
+    # execute in your eZ Platform project working directory:
+    cd src
+    # this directory is needed to generate autoload conforming to PSR-0
+    mkdir EzSystems && cd EzSystems
+    # clone `CookbookBundle`
+    git clone git@github.com:ezsystems/CookbookBundle.git CookbookBundle
+    cd ../..
+    # dump composer autoloader
+    composer dump-autoload
+    ```
+
+3. Enable the bundle in `AppKernel.php`:
+
+    ```php
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+            new EzSystems\CookbookBundle\EzSystemsCookbookBundle(),
+        );
+
+        // ...
+    }
+    ```
+
+4. Clear Symfony cache
+
+    ```bash
+    php app/console cache:clear
+    ```
+
+5. Try already defined commands. You can find all available commands by:
+
+   ```bash
+   php app/console |grep 'ezpublish:cookbook'
+   ```
+
+That's all!


### PR DESCRIPTION
To showcase something for the Doc Team I tried to use this bundle and failed :) 
...so here there is the fix and README improvement.

- [x] Renamed in dacb1d5 `CreateXMLContentCommand` due to case mismatch (Symfony cache warmup crashed).
- [x] Based on my experience today I decided to improve `README.md` with a quick guide for a new developer to start "playing" with the bundle (86744ef). Hope you'll like it.

The remaining thing to do (separate PR) is maybe to introduce `.php_cs` config for fixer, however there is a lot of changes, so I'm not sure (I took conf from ezplatform and fixer changed 23 files out of 24 in the bundle).