### PR TITLE
Add composer.json in order to prepare for Packagist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "ezsystems/cookbook-bundle",
+    "description": "eZ Platform Bundle with ready to use code samples",
+    "homepage": "https://github.com/ezsystems/CookbookBundle",
+    "license": "GPL-2.0",
+    "type": "ezplatform-bundle",
+    "authors": [
+        {
+            "name": "eZ dev-team & eZ Community",
+            "homepage": "https://github.com/ezsystems/CookbookBundle/contributors"
+        }
+    ],
+    "require": {
+        "php": "^5.6|^7.0",
+        "ezsystems/ezpublish-kernel": "^6.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "EzSystems\\CookbookBundle\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `composer.json` file which is the first step towards #11 - adding this repository to Packagist.

When CookbookBundle gets added there, it will be available for any eZ Platform project by:
```bash
composer require ezsystems/cookbook-bundle dev-master
```

*Side note: before actually adding CookbookBundle to Packagist I'm going to solve #13 and #14*